### PR TITLE
Corrected implementation of MutableMap.addRandomDuck(). 

### DIFF
--- a/duckShopServer/duckShopServerAddElements/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
+++ b/duckShopServer/duckShopServerAddElements/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
@@ -19,7 +19,7 @@ class GameChangeFunctionsService  {
     fun MutableMap<Duck, String>.addRandomDuck(): Pair<Duck, String> {
         val duck = keys.getNewRandomDuck()
         return Pair(duck, duck.getDescription()).also { (duck, d) ->
-            toMutableMap()[duck] = d
+            this[duck] = d
         }
     }
 

--- a/duckShopServer/duckShopServerAddElements/test/Tests.kt
+++ b/duckShopServer/duckShopServerAddElements/test/Tests.kt
@@ -62,7 +62,9 @@ class Test {
         val addedDucks = mutableListOf<Pair<Duck, String>>()
         val possibleDucks = Duck.entries.toList()
         repeat(100) {
-            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }
+            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }.toMutableMap()
+            val beforeKeys = currentDucks.keys.toSet()
+            val beforeSize = currentDucks.size
             try {
                 val output =
                     gameChangeFunctionsServiceTestClass.invokeMethodWithArgs(currentDucks, invokeData = invokeData)
@@ -70,7 +72,16 @@ class Test {
                     assertTrue(false) { "$errorPrefix for the map $currentDucks it returns $output" }
                     Pair(Duck.Alex, Duck.Alex.getDescription())
                 }
-                assertTrue(duckWithDescription.first !in currentDucks.keys) { "$errorPrefix for the map $currentDucks it generated $duckWithDescription that is already in the map" }
+                val (duck, desc) = duckWithDescription
+                assertTrue(duck !in beforeKeys) {
+                    "$errorPrefix for the map $currentDucks it generated $duckWithDescription that was already in the map before call"
+                }
+                assertTrue(currentDucks.size == beforeSize + 1) {
+                    "$errorPrefix map size did not increase by 1"
+                }
+                assertTrue(currentDucks[duck] == desc) {
+                    "$errorPrefix stored value for $duck is ${currentDucks[duck]}, expected $desc"
+                }
                 addedDucks.add(duckWithDescription)
             } catch (e: InvocationTargetException) {
                 assertTrue(false) { "$errorPrefix it throws an exception" }

--- a/duckShopServer/duckShopServerBuiltInFunctions/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
+++ b/duckShopServer/duckShopServerBuiltInFunctions/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
@@ -19,7 +19,7 @@ class GameChangeFunctionsService  {
     fun MutableMap<Duck, String>.addRandomDuck(): Pair<Duck, String> {
         val duck = keys.getNewRandomDuck()
         return Pair(duck, duck.getDescription()).also { (duck, d) ->
-            toMutableMap()[duck] = d
+            this[duck] = d
         }
     }
 

--- a/duckShopServer/duckShopServerFilter/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
+++ b/duckShopServer/duckShopServerFilter/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
@@ -19,7 +19,7 @@ class GameChangeFunctionsService  {
     fun MutableMap<Duck, String>.addRandomDuck(): Pair<Duck, String> {
         val duck = keys.getNewRandomDuck()
         return Pair(duck, duck.getDescription()).also { (duck, d) ->
-            toMutableMap()[duck] = d
+            this[duck] = d
         }
     }
 

--- a/duckShopServer/duckShopServerFilter/test/Tests.kt
+++ b/duckShopServer/duckShopServerFilter/test/Tests.kt
@@ -98,9 +98,11 @@ class Test {
         val invokeData = TestMethodInvokeData(gameChangeFunctionsServiceTestClass, addRandomDuckMapMethod)
         val errorPrefix = "The method ${addRandomDuckMapMethod.name} should add a random duck to a map of ducks, but "
         val addedDucks = mutableListOf<Pair<Duck, String>>()
-        val possibleDucks = Duck.entries
+        val possibleDucks = Duck.entries.toList()
         repeat(100) {
-            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }
+            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }.toMutableMap()
+            val beforeKeys = currentDucks.keys.toSet()
+            val beforeSize = currentDucks.size
             try {
                 val output =
                     gameChangeFunctionsServiceTestClass.invokeMethodWithArgs(currentDucks, invokeData = invokeData)
@@ -108,7 +110,16 @@ class Test {
                     assertTrue(false) { "$errorPrefix for the map $currentDucks it returns $output" }
                     Pair(Duck.Alex, Duck.Alex.getDescription())
                 }
-                assertTrue(duckWithDescription.first !in currentDucks.keys) { "$errorPrefix for the map $currentDucks it generated $duckWithDescription that is already in the map" }
+                val (duck, desc) = duckWithDescription
+                assertTrue(duck !in beforeKeys) {
+                    "$errorPrefix for the map $currentDucks it generated $duckWithDescription that was already in the map before call"
+                }
+                assertTrue(currentDucks.size == beforeSize + 1) {
+                    "$errorPrefix map size did not increase by 1"
+                }
+                assertTrue(currentDucks[duck] == desc) {
+                    "$errorPrefix stored value for $duck is ${currentDucks[duck]}, expected $desc"
+                }
                 addedDucks.add(duckWithDescription)
             } catch (e: InvocationTargetException) {
                 assertTrue(false) { "$errorPrefix it throws an exception" }

--- a/duckShopServer/duckShopServerImprovments/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
+++ b/duckShopServer/duckShopServerImprovments/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
@@ -19,7 +19,7 @@ class GameChangeFunctionsService  {
     fun MutableMap<Duck, String>.addRandomDuck(): Pair<Duck, String> {
         val duck = keys.getNewRandomDuck()
         return Pair(duck, duck.getDescription()).also { (duck, d) ->
-            toMutableMap()[duck] = d
+            this[duck] = d
         }
     }
 

--- a/duckShopServer/duckShopServerPartition/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
+++ b/duckShopServer/duckShopServerPartition/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
@@ -19,7 +19,7 @@ class GameChangeFunctionsService  {
     fun MutableMap<Duck, String>.addRandomDuck(): Pair<Duck, String> {
         val duck = keys.getNewRandomDuck()
         return Pair(duck, duck.getDescription()).also { (duck, d) ->
-            toMutableMap()[duck] = d
+            this[duck] = d
         }
     }
 

--- a/duckShopServer/duckShopServerPartition/test/Tests.kt
+++ b/duckShopServer/duckShopServerPartition/test/Tests.kt
@@ -119,7 +119,9 @@ class Test {
         val addedDucks = mutableListOf<Pair<Duck, String>>()
         val possibleDucks = Duck.entries.toList()
         repeat(100) {
-            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }
+            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }.toMutableMap()
+            val beforeKeys = currentDucks.keys.toSet()
+            val beforeSize = currentDucks.size
             try {
                 val output =
                     gameChangeFunctionsServiceTestClass.invokeMethodWithArgs(currentDucks, invokeData = invokeData)
@@ -127,7 +129,16 @@ class Test {
                     assertTrue(false) { "$errorPrefix for the map $currentDucks it returns $output" }
                     Pair(Duck.Alex, Duck.Alex.getDescription())
                 }
-                assertTrue(duckWithDescription.first !in currentDucks.keys) { "$errorPrefix for the map $currentDucks it generated $duckWithDescription that is already in the map" }
+                val (duck, desc) = duckWithDescription
+                assertTrue(duck !in beforeKeys) {
+                    "$errorPrefix for the map $currentDucks it generated $duckWithDescription that was already in the map before call"
+                }
+                assertTrue(currentDucks.size == beforeSize + 1) {
+                    "$errorPrefix map size did not increase by 1"
+                }
+                assertTrue(currentDucks[duck] == desc) {
+                    "$errorPrefix stored value for $duck is ${currentDucks[duck]}, expected $desc"
+                }
                 addedDucks.add(duckWithDescription)
             } catch (e: InvocationTargetException) {
                 assertTrue(false) { "$errorPrefix it throws an exception" }

--- a/duckShopServer/duckShopServerShuffle/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
+++ b/duckShopServer/duckShopServerShuffle/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
@@ -19,7 +19,7 @@ class GameChangeFunctionsService  {
     fun MutableMap<Duck, String>.addRandomDuck(): Pair<Duck, String> {
         val duck = keys.getNewRandomDuck()
         return Pair(duck, duck.getDescription()).also { (duck, d) ->
-            toMutableMap()[duck] = d
+            this[duck] = d
         }
     }
 

--- a/duckShopServer/duckShopServerShuffle/test/Tests.kt
+++ b/duckShopServer/duckShopServerShuffle/test/Tests.kt
@@ -141,7 +141,9 @@ class Test {
         val addedDucks = mutableListOf<Pair<Duck, String>>()
         val possibleDucks = Duck.entries.toList()
         repeat(100) {
-            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }
+            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }.toMutableMap()
+            val beforeKeys = currentDucks.keys.toSet()
+            val beforeSize = currentDucks.size
             try {
                 val output =
                     gameChangeFunctionsServiceTestClass.invokeMethodWithArgs(currentDucks, invokeData = invokeData)
@@ -149,7 +151,16 @@ class Test {
                     assertTrue(false) { "$errorPrefix for the map $currentDucks it returns $output" }
                     Pair(Duck.Alex, Duck.Alex.getDescription())
                 }
-                assertTrue(duckWithDescription.first !in currentDucks.keys) { "$errorPrefix for the map $currentDucks it generated $duckWithDescription that is already in the map" }
+                val (duck, desc) = duckWithDescription
+                assertTrue(duck !in beforeKeys) {
+                    "$errorPrefix for the map $currentDucks it generated $duckWithDescription that was already in the map before call"
+                }
+                assertTrue(currentDucks.size == beforeSize + 1) {
+                    "$errorPrefix map size did not increase by 1"
+                }
+                assertTrue(currentDucks[duck] == desc) {
+                    "$errorPrefix stored value for $duck is ${currentDucks[duck]}, expected $desc"
+                }
                 addedDucks.add(duckWithDescription)
             } catch (e: InvocationTargetException) {
                 assertTrue(false) { "$errorPrefix it throws an exception" }

--- a/duckShopServer/duckShopServerSortFunction/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
+++ b/duckShopServer/duckShopServerSortFunction/src/main/kotlin/org/jetbrains/kotlin/course/duck/shop/functions/change/GameChangeFunctionsService.kt
@@ -19,7 +19,7 @@ class GameChangeFunctionsService  {
     fun MutableMap<Duck, String>.addRandomDuck(): Pair<Duck, String> {
         val duck = keys.getNewRandomDuck()
         return Pair(duck, duck.getDescription()).also { (duck, d) ->
-            toMutableMap()[duck] = d
+            this[duck] = d
         }
     }
 

--- a/duckShopServer/duckShopServerSortFunction/test/Tests.kt
+++ b/duckShopServer/duckShopServerSortFunction/test/Tests.kt
@@ -169,7 +169,9 @@ class Test {
         val addedDucks = mutableListOf<Pair<Duck, String>>()
         val possibleDucks = Duck.entries.toList()
         repeat(100) {
-            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }
+            val currentDucks = possibleDucks.shuffled().take(MAX_NUMBER_OF_DUCKS).associateWith { it.getDescription() }.toMutableMap()
+            val beforeKeys = currentDucks.keys.toSet()
+            val beforeSize = currentDucks.size
             try {
                 val output =
                     gameChangeFunctionsServiceTestClass.invokeMethodWithArgs(currentDucks, invokeData = invokeData)
@@ -177,7 +179,16 @@ class Test {
                     assertTrue(false) { "$errorPrefix for the map $currentDucks it returns $output" }
                     Pair(Duck.Alex, Duck.Alex.getDescription())
                 }
-                assertTrue(duckWithDescription.first !in currentDucks.keys) { "$errorPrefix for the map $currentDucks it generated $duckWithDescription that is already in the map" }
+                val (duck, desc) = duckWithDescription
+                assertTrue(duck !in beforeKeys) {
+                    "$errorPrefix for the map $currentDucks it generated $duckWithDescription that was already in the map before call"
+                }
+                assertTrue(currentDucks.size == beforeSize + 1) {
+                    "$errorPrefix map size did not increase by 1"
+                }
+                assertTrue(currentDucks[duck] == desc) {
+                    "$errorPrefix stored value for $duck is ${currentDucks[duck]}, expected $desc"
+                }
                 addedDucks.add(duckWithDescription)
             } catch (e: InvocationTargetException) {
                 assertTrue(false) { "$errorPrefix it throws an exception" }


### PR DESCRIPTION
It didn't add a duck to the map, just returned a Pair. Also, the method's test is corrected in response to changes.