### PR TITLE
Use last ubuntu instead of old ubuntu-20.04 for `Gradle Build` workflow

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v7
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.0.0
+        uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: liberica
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1.0.4
-      - uses: gradle/gradle-build-action@v2.1.5
-        with:
-          arguments: build --stacktrace
+        uses: gradle/actions/wrapper-validation@v6
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Build
+        run: ./gradlew build --stacktrace
           

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3.0.0

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,6 +1,9 @@
 name: Gradle Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis


### PR DESCRIPTION
- use `ubuntu-latest` instead of all `ubuntu-20.04`. It fixes the workflow itself
- update workflow dependencies to use the latest ones and avoid using deprecated GitHub API (via old workflow actions)
- avoid running build workflow twice for PR